### PR TITLE
Update job DSL and install iproute2 into Jenkins image

### DIFF
--- a/jenkins-docker/Dockerfile
+++ b/jenkins-docker/Dockerfile
@@ -6,6 +6,13 @@ ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/casc_configs
 
 ENV JAVA_OPTS=-Djenkins.install.runSetupWizard=false
 
+# install the "ip" executable called by se.bjurr.jenkinssandbox.JenkinsSandboxUtils#getHostIp()
+USER root
+RUN apt-get update \
+      && apt-get install -y iproute2 \
+      && rm -rf /var/lib/apt/lists/*
+USER jenkins
+
 RUN install-plugins.sh \
   configuration-as-code \
   blueocean \

--- a/jenkins-docker/jenkins.yaml
+++ b/jenkins-docker/jenkins.yaml
@@ -58,7 +58,9 @@ jobs:
   - script: >
       pipelineJob('Create Jobs Pipeline') {
         quietPeriod(0)
-        concurrentBuild(false)
+        properties {
+          disableConcurrentBuilds()
+        }
         logRotator {
           numToKeep(10)
         }

--- a/jobs/applicationRepo.groovy
+++ b/jobs/applicationRepo.groovy
@@ -24,7 +24,9 @@ def createSnapshotJob(repoFolder, repo) {
   pipelineJob(repoFolder+'/snapshot') {
     description('Triggered when pusing to default branch in GitLab ('+repo.default_branch+').')
     quietPeriod(0)
-    concurrentBuild(false)
+    properties {
+      disableConcurrentBuilds()
+    }
     logRotator {
       numToKeep(10)
     }
@@ -72,7 +74,9 @@ def createReleaseJob(repoFolder, repo) {
     description('Triggered when pusing tag to repo in GitLab ('+repo.cloneUrl+'). '
               + 'Or when run manually.')
     quietPeriod(0)
-    concurrentBuild(false)
+    properties {
+      disableConcurrentBuilds()
+    }
     logRotator {
       numToKeep(10)
     }
@@ -126,7 +130,9 @@ def createReleaseJob(repoFolder, repo) {
 def createMergeRequestJob(repoFolder, repo) {
   pipelineJob(repoFolder+'/merge-request') {
     quietPeriod(0)
-    concurrentBuild(true)
+    properties {
+      disableConcurrentBuilds()
+    }
     logRotator {
       numToKeep(10)
     }


### PR DESCRIPTION
This PR addresses #7:
* It replaces `concurrentBuild(false)` in all job definitions by `properties { disableConcurrentBuilds() }` because the former method was apparently dropped from the job DSL plugin.
* `getHostIp()` in [src/se/bjurr/jenkinssandbox/JenkinsSandboxUtils.groovy](https://github.com/tomasbjerre/jenkins-configuration-as-code-sandbox/blob/db7292e4ec7a02706f297c6915bfac6a52534452/src/se/bjurr/jenkinssandbox/JenkinsSandboxUtils.groovy#L7) fails because the executable `ip` is not installed (anymore?) in the Docker image `jenkins/jenkins:lts`. Therefore, this PR installs the `iproute2` package into the Jenkins image.